### PR TITLE
Add support for python3; PEP8 cleanup

### DIFF
--- a/nnpcr.py
+++ b/nnpcr.py
@@ -1,11 +1,16 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
-import cPickle
+try:
+    import cPickle as pickle
+    from urllib2 import urlopen
+except ImportError:
+    import pickle
+    from urllib.request import urlopen
+
 import sys
 import os
 import random
 import cv2
-import urllib2
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.ops import init_ops
@@ -15,298 +20,312 @@ import logging
 FILE_SEED = 42
 IMG_SIZE = 128
 
+
 def loadCache(fname):
-	return cPickle.load(open(fname, 'rb'))
+    return pickle.load(open(fname, 'rb'))
+
 
 def saveCache(obj, fileName):
-	cPickle.dump(obj, open(fileName + '.tmp', 'wb'), -1)
-	os.rename(fileName + '.tmp', fileName)
+    pickle.dump(obj, open(fileName + '.tmp', 'wb'), -1)
+    os.rename(fileName + '.tmp', fileName)
+
 
 def loadDir(dirName):
-	files = os.listdir(dirName)
-	fnames = []
-	for f in files:
-		if not f.endswith('.jpg'):
-			continue
-		fileName = dirName + '/' + f
-		fnames.append(fileName)
-	return fnames
+    files = os.listdir(dirName)
+    fnames = []
+    for f in files:
+        if not f.endswith('.jpg'):
+            continue
+        fileName = dirName + '/' + f
+        fnames.append(fileName)
+    return fnames
+
 
 def loadFileLists():
-	random.seed(FILE_SEED)
+    random.seed(FILE_SEED)
 
-	positiveFiles = sorted(loadDir('2'))
-	negativeFiles = sorted(loadDir('1'))
+    positiveFiles = sorted(loadDir('2'))
+    negativeFiles = sorted(loadDir('1'))
 
-	random.shuffle(positiveFiles)
-	random.shuffle(negativeFiles)
+    random.shuffle(positiveFiles)
+    random.shuffle(negativeFiles)
 
-	minLen = min(len(positiveFiles), len(negativeFiles))
+    minLen = min(len(positiveFiles), len(negativeFiles))
 
-	p20 = int(0.2 * minLen)
+    p20 = int(0.2 * minLen)
 
-	testPositive = positiveFiles[:p20]
-	testNegative = negativeFiles[:p20]
-	positiveFiles = positiveFiles[p20:]
-	negativeFiles = negativeFiles[p20:]
+    testPositive = positiveFiles[:p20]
+    testNegative = negativeFiles[:p20]
+    positiveFiles = positiveFiles[p20:]
+    negativeFiles = negativeFiles[p20:]
 
-	trainSamples = [(f, 1) for f in positiveFiles] + [(f, 0) for f in negativeFiles]
-	testSamples = [(f, 1) for f in testPositive] + [(f, 0) for f in testNegative]
+    trainSamples = [(f, 1) for f in positiveFiles] + [(f, 0) for f in negativeFiles]
+    testSamples = [(f, 1) for f in testPositive] + [(f, 0) for f in testNegative]
 
-	random.shuffle(trainSamples)
-	random.shuffle(testSamples)
+    random.shuffle(trainSamples)
+    random.shuffle(testSamples)
 
-	trainX = [e[0] for e in trainSamples]
-	trainY = [e[1] for e in trainSamples]
-	testX = [e[0] for e in testSamples]
-	testY = [e[1] for e in testSamples]
+    trainX = [e[0] for e in trainSamples]
+    trainY = [e[1] for e in trainSamples]
+    testX = [e[0] for e in testSamples]
+    testY = [e[1] for e in testSamples]
 
-	return trainX, trainY, testX, testY
+    return trainX, trainY, testX, testY
+
 
 def loadFeatures(files):
-	data = np.ndarray((len(files), IMG_SIZE * IMG_SIZE * 3))
-	for n, f in enumerate(files):
-		logging.debug('loading file #%d' % n)
-		img = cv2.imread(f)
-		# print img.shape
-		#img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-		#cv2.imshow("orig", img)
-		h, w, _ = img.shape
-		if w > h:
-			diff = w - h
-			img = img[:, diff / 2 : diff / 2 + h]
-		elif w < h:
-			diff = h - w
-			img = img[diff / 2 : diff / 2 + w,:]
-		img = cv2.resize(img, (IMG_SIZE, IMG_SIZE))
-		data[n] = img.ravel()
-		# cv2.imshow("res", img)
-		# cv2.waitKey(0)
-	return data
+    data = np.ndarray((len(files), IMG_SIZE * IMG_SIZE * 3))
+    for n, f in enumerate(files):
+        logging.debug('loading file #%d' % n)
+        img = cv2.imread(f)
+        # print(img.shape)
+        #img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        #cv2.imshow("orig", img)
+        h, w, _ = img.shape
+        if w > h:
+            diff = w - h
+            img = img[:, diff / 2: diff / 2 + h]
+        elif w < h:
+            diff = h - w
+            img = img[diff / 2: diff / 2 + w, :]
+        img = cv2.resize(img, (IMG_SIZE, IMG_SIZE))
+        data[n] = img.ravel()
+        # cv2.imshow("res", img)
+        # cv2.waitKey(0)
+    return data
+
 
 def denseToOneHot(labels_dense, num_classes):
-	"""Convert class labels from scalars to one-hot vectors."""
-	num_labels = labels_dense.shape[0]
-	index_offset = np.arange(num_labels) * num_classes
-	labels_one_hot = np.zeros((num_labels, num_classes))
-	labels_one_hot.flat[index_offset + labels_dense.ravel()] = 1
-	return labels_one_hot
+    """Convert class labels from scalars to one-hot vectors."""
+    num_labels = labels_dense.shape[0]
+    index_offset = np.arange(num_labels) * num_classes
+    labels_one_hot = np.zeros((num_labels, num_classes))
+    labels_one_hot.flat[index_offset + labels_dense.ravel()] = 1
+    return labels_one_hot
+
 
 def loadDataset():
-	try:
-		trainX, trainY, testX, testY = loadCache('nncache.bin')
-	except:
-		trainX, trainY, testX, testY = loadFileLists()
-		trainX = loadFeatures(trainX)
-		testX = loadFeatures(testX)
-		saveCache((trainX, trainY, testX, testY), 'nncache.bin')
-	trainY = denseToOneHot(np.array(trainY), 2)
-	testY = denseToOneHot(np.array(testY), 2)
-	return trainX, trainY, testX, testY
+    try:
+        trainX, trainY, testX, testY = loadCache('nncache.bin')
+    except:
+        trainX, trainY, testX, testY = loadFileLists()
+        trainX = loadFeatures(trainX)
+        testX = loadFeatures(testX)
+        saveCache((trainX, trainY, testX, testY), 'nncache.bin')
+    trainY = denseToOneHot(np.array(trainY), 2)
+    testY = denseToOneHot(np.array(testY), 2)
+    return trainX, trainY, testX, testY
 
 
 class Batcher(object):
-	def __init__(self, x, y, batchSize):
-		assert len(y) >= batchSize
-		self.__batchSize = batchSize
-		self.__x = x
-		self.__y = y
-		self.shuffle()
-		self.__currentIdx = 0
-		self.__epochNumber = 0
 
-	def shuffle(self):
-		perm = np.arange(len(self.__y))
-		np.random.shuffle(perm)
-		self.__x = self.__x[perm]
-		self.__y = self.__y[perm]
+    def __init__(self, x, y, batchSize):
+        assert len(y) >= batchSize
+        self.__batchSize = batchSize
+        self.__x = x
+        self.__y = y
+        self.shuffle()
+        self.__currentIdx = 0
+        self.__epochNumber = 0
 
-	def nextBatch(self):
-		nextIdx = self.__currentIdx + self.__batchSize
-		if nextIdx > len(self.__y):
-			nextIdx = self.__batchSize
-			self.__currentIdx = 0
-			self.shuffle()
-			self.__epochNumber += 1
-		x = self.__x[self.__currentIdx:nextIdx]
-		y = self.__y[self.__currentIdx:nextIdx]
-		self.__currentIdx = nextIdx
-		return x, y
+    def shuffle(self):
+        perm = np.arange(len(self.__y))
+        np.random.shuffle(perm)
+        self.__x = self.__x[perm]
+        self.__y = self.__y[perm]
 
-	def getEpochNumber(self):
-		return self.__epochNumber
+    def nextBatch(self):
+        nextIdx = self.__currentIdx + self.__batchSize
+        if nextIdx > len(self.__y):
+            nextIdx = self.__batchSize
+            self.__currentIdx = 0
+            self.shuffle()
+            self.__epochNumber += 1
+        x = self.__x[self.__currentIdx:nextIdx]
+        y = self.__y[self.__currentIdx:nextIdx]
+        self.__currentIdx = nextIdx
+        return x, y
+
+    def getEpochNumber(self):
+        return self.__epochNumber
 
 
 def weight_variable(shape):
-	initial = tf.truncated_normal(shape, stddev=0.1)
-	return tf.Variable(initial)
+    initial = tf.truncated_normal(shape, stddev=0.1)
+    return tf.Variable(initial)
+
 
 def bias_variable(shape):
-	initial = tf.constant(0.1, shape=shape)
-	return tf.Variable(initial)
+    initial = tf.constant(0.1, shape=shape)
+    return tf.Variable(initial)
+
 
 def conv2d(x, W):
-	return tf.nn.conv2d(x, W, strides=[1, 1, 1, 1], padding='SAME')
+    return tf.nn.conv2d(x, W, strides=[1, 1, 1, 1], padding='SAME')
+
 
 def max_pool_2x2(x):
-	return tf.nn.max_pool(x, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding='SAME')
+    return tf.nn.max_pool(x, ksize=[1, 2, 2, 1], strides=[1, 2, 2, 1], padding='SAME')
 
 xavier = tf.contrib.layers.xavier_initializer
 
+
 class Estimator(object):
 
-	def __init__(self):
-		x = tf.placeholder(tf.float32, shape=[None, IMG_SIZE * IMG_SIZE * 3])
-		y_ = tf.placeholder(tf.float32, shape=[None, 2])
+    def __init__(self):
+        x = tf.placeholder(tf.float32, shape=[None, IMG_SIZE * IMG_SIZE * 3])
+        y_ = tf.placeholder(tf.float32, shape=[None, 2])
 
-		x_image = tf.reshape(x, [-1, IMG_SIZE, IMG_SIZE, 3])		# 128
+        x_image = tf.reshape(x, [-1, IMG_SIZE, IMG_SIZE, 3])		# 128
 
-		W_conv1 = tf.get_variable("W_conv1", shape=[3, 3, 3, 6], initializer=xavier())
-		b_conv1 = tf.get_variable('b_conv1', [1, 1, 1, 6])
-		h_conv1 = tf.nn.relu(conv2d(x_image, W_conv1) + b_conv1)
-		h_pool1 = max_pool_2x2(h_conv1)								# 64
+        W_conv1 = tf.get_variable("W_conv1", shape=[3, 3, 3, 6], initializer=xavier())
+        b_conv1 = tf.get_variable('b_conv1', [1, 1, 1, 6])
+        h_conv1 = tf.nn.relu(conv2d(x_image, W_conv1) + b_conv1)
+        h_pool1 = max_pool_2x2(h_conv1)								# 64
 
-		W_conv2 = tf.get_variable("W_conv2", shape=[3, 3, 6, 6], initializer=xavier())
-		b_conv2 = tf.get_variable('b_conv2', [1, 1, 1, 6])
-		h_conv2 = tf.nn.relu(conv2d(h_pool1, W_conv2) + b_conv2)
-		h_pool2 = max_pool_2x2(h_conv2)								# 32
+        W_conv2 = tf.get_variable("W_conv2", shape=[3, 3, 6, 6], initializer=xavier())
+        b_conv2 = tf.get_variable('b_conv2', [1, 1, 1, 6])
+        h_conv2 = tf.nn.relu(conv2d(h_pool1, W_conv2) + b_conv2)
+        h_pool2 = max_pool_2x2(h_conv2)								# 32
 
-		W_conv3 = tf.get_variable("W_conv3", shape=[3, 3, 6, 12], initializer=xavier())
-		b_conv3 = tf.get_variable('b_conv3', [1, 1, 1, 12])
-		h_conv3 = tf.nn.relu(conv2d(h_pool2, W_conv3) + b_conv3)
-		h_pool3 = max_pool_2x2(h_conv3)								# 16
+        W_conv3 = tf.get_variable("W_conv3", shape=[3, 3, 6, 12], initializer=xavier())
+        b_conv3 = tf.get_variable('b_conv3', [1, 1, 1, 12])
+        h_conv3 = tf.nn.relu(conv2d(h_pool2, W_conv3) + b_conv3)
+        h_pool3 = max_pool_2x2(h_conv3)								# 16
 
-		W_conv4 = tf.get_variable("W_conv4", shape=[3, 3, 12, 24], initializer=xavier())
-		b_conv4 = tf.get_variable('b_conv4', [1, 1, 1, 24])
-		h_conv4 = tf.nn.relu(conv2d(h_pool3, W_conv4) + b_conv4)
-		h_pool4 = max_pool_2x2(h_conv4)								# 8
+        W_conv4 = tf.get_variable("W_conv4", shape=[3, 3, 12, 24], initializer=xavier())
+        b_conv4 = tf.get_variable('b_conv4', [1, 1, 1, 24])
+        h_conv4 = tf.nn.relu(conv2d(h_pool3, W_conv4) + b_conv4)
+        h_pool4 = max_pool_2x2(h_conv4)								# 8
 
-		h_pool4_flat = tf.reshape(h_pool4, [-1, 8 * 8 * 24])
+        h_pool4_flat = tf.reshape(h_pool4, [-1, 8 * 8 * 24])
 
+        W_fc1 = tf.get_variable("W_fc1", shape=[8 * 8 * 24, 1024], initializer=xavier())
+        b_fc1 = tf.get_variable('b_fc1', [1024], initializer=init_ops.zeros_initializer)
+        h_fc1 = tf.nn.relu(tf.matmul(h_pool4_flat, W_fc1) + b_fc1)
 
-		W_fc1 = tf.get_variable("W_fc1", shape=[8 * 8 * 24, 1024], initializer=xavier())
-		b_fc1 = tf.get_variable('b_fc1', [1024], initializer=init_ops.zeros_initializer)
-		h_fc1 = tf.nn.relu(tf.matmul(h_pool4_flat, W_fc1) + b_fc1)
+        keep_prob = tf.placeholder(tf.float32)
+        h_fc1_drop = tf.nn.dropout(h_fc1, keep_prob)
 
-		keep_prob = tf.placeholder(tf.float32)
-		h_fc1_drop = tf.nn.dropout(h_fc1, keep_prob)
+        W_fcO = tf.get_variable("W_fcO", shape=[1024, 2], initializer=xavier())
+        b_fcO = tf.get_variable('b_fcO', [2], initializer=init_ops.zeros_initializer)
 
-		W_fcO = tf.get_variable("W_fcO", shape=[1024, 2], initializer=xavier())
-		b_fcO = tf.get_variable('b_fcO', [2], initializer=init_ops.zeros_initializer)
+        logits = tf.matmul(h_fc1_drop, W_fcO) + b_fcO
+        y_conv = tf.nn.softmax(logits)
 
-		logits = tf.matmul(h_fc1_drop, W_fcO) + b_fcO
-		y_conv = tf.nn.softmax(logits)
+        cross_entropy = loss_ops.softmax_cross_entropy(logits, y_)
 
-		cross_entropy = loss_ops.softmax_cross_entropy(logits, y_)
+        train_step = tf.train.AdagradOptimizer(0.01).minimize(cross_entropy)
 
-		train_step = tf.train.AdagradOptimizer(0.01).minimize(cross_entropy)
+        self.predictions = predictions = tf.argmax(y_conv, 1)
 
-		self.predictions = predictions = tf.argmax(y_conv, 1)
+        correct_prediction = tf.equal(predictions, tf.argmax(y_, 1))
+        accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
 
-		correct_prediction = tf.equal(predictions, tf.argmax(y_, 1))
-		accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))
+        self.x = x
+        self.y_ = y_
+        self.keep_prob = keep_prob
+        self.trainStep = train_step
+        self.accuracy = accuracy
 
-		self.x = x
-		self.y_ = y_
-		self.keep_prob = keep_prob
-		self.trainStep = train_step
-		self.accuracy = accuracy
+    def train(self, x, y, keepProb=1.0):
+        self.trainStep.run(feed_dict={
+            self.x: x,
+            self.y_: y,
+            self.keep_prob: keepProb,
+        })
 
-	def train(self, x, y, keepProb = 1.0):
-		self.trainStep.run(feed_dict = {
-			self.x: x,
-			self.y_: y,
-			self.keep_prob: keepProb,
-		})
+    def getAccuracy(self, x, y):
+        return self.accuracy.eval(feed_dict={
+            self.x: x,
+            self.y_: y,
+            self.keep_prob: 1.0,
+        })
 
-	def getAccuracy(self, x, y):
-		return self.accuracy.eval(feed_dict = {
-			self.x: x,
-			self.y_: y,
-			self.keep_prob: 1.0,
-		})
+    def predict(self, x):
+        return self.predictions.eval(feed_dict={
+            self.x: x,
+            self.keep_prob: 1.0,
+        })
 
-	def predict(self, x):
-		return self.predictions.eval(feed_dict = {
-			self.x: x,
-			self.keep_prob: 1.0,
-		})
 
 class NNPCR(object):
 
-	def __init__(self):
-		tf.set_random_seed(FILE_SEED)
-		self.__sess = tf.InteractiveSession()
-		self.__est = Estimator()
+    def __init__(self):
+        tf.set_random_seed(FILE_SEED)
+        self.__sess = tf.InteractiveSession()
+        self.__est = Estimator()
 
-	def train(self, numIterations = 1500):
-		logging.info('loading dataset')
-		trainX, trainY, testX, testY = loadDataset()
-		batcher = Batcher(trainX, trainY, 100)
+    def train(self, numIterations=1500):
+        logging.info('loading dataset')
+        trainX, trainY, testX, testY = loadDataset()
+        batcher = Batcher(trainX, trainY, 100)
 
-		self.__sess.run(tf.initialize_all_variables())
+        self.__sess.run(tf.initialize_all_variables())
 
-		logging.info('training')
+        logging.info('training')
 
-		for i in range(numIterations):
-			if i % 50 == 0:
-				en = batcher.getEpochNumber()
-				acc = self.__est.getAccuracy(testX, testY)
-				logging.info('epoch %d, iteration %d, accuracy %f' % (en, i, acc))
-			batch = batcher.nextBatch()
-			self.__est.train(batch[0], batch[1], keepProb=0.5)
+        for i in range(numIterations):
+            if i % 50 == 0:
+                en = batcher.getEpochNumber()
+                acc = self.__est.getAccuracy(testX, testY)
+                logging.info('epoch %d, iteration %d, accuracy %f' % (en, i, acc))
+            batch = batcher.nextBatch()
+            self.__est.train(batch[0], batch[1], keepProb=0.5)
 
-	def testAccuracy(self):
-		logging.info('loading dataset')
-		trainX, trainY, testX, testY = loadDataset()
-		return self.__est.getAccuracy(trainX, trainY), self.__est.getAccuracy(testX, testY)
+    def testAccuracy(self):
+        logging.info('loading dataset')
+        trainX, trainY, testX, testY = loadDataset()
+        return self.__est.getAccuracy(trainX, trainY), self.__est.getAccuracy(testX, testY)
 
-	def saveModel(self, fileName):
-		saver = tf.train.Saver()
-		saver.save(self.__sess, fileName)
+    def saveModel(self, fileName):
+        saver = tf.train.Saver()
+        saver.save(self.__sess, fileName)
 
-	def loadModel(self, fileName):
-		saver = tf.train.Saver()
-		saver.restore(self.__sess, fileName)
+    def loadModel(self, fileName):
+        saver = tf.train.Saver()
+        saver.restore(self.__sess, fileName)
 
-	def predict(self, files):
-		features = loadFeatures(files)
-		return self.__est.predict(features)
+    def predict(self, files):
+        features = loadFeatures(files)
+        return self.__est.predict(features)
+
 
 def printUsage():
-	print 'Usage: '
-	print '  %s train                              - train model' % sys.argv[0]
-	print '  %s file testImg.jpg                   - check given file' % sys.argv[0]
-	print '  %s url http://sample.com/img.jpg      - check given url' % sys.argv[0]
-	sys.exit(42)
+    print('Usage: ')
+    print('  %s train                              - train model' % sys.argv[0])
+    print('  %s file testImg.jpg                   - check given file' % sys.argv[0])
+    print('  %s url http://sample.com/img.jpg      - check given url' % sys.argv[0])
+    sys.exit(42)
+
 
 if __name__ == '__main__':
 
-	logging.basicConfig(format = u'[%(asctime)s %(filename)s:%(lineno)d %(levelname)s]  %(message)s', level = logging.INFO)
+    logging.basicConfig(format=u'[%(asctime)s %(filename)s:%(lineno)d %(levelname)s]  %(message)s', level=logging.INFO)
 
-	pcr = NNPCR()
+    pcr = NNPCR()
 
-	if len(sys.argv) < 2:
-		printUsage()
-	mode = sys.argv[1]
-	if mode == 'train':
-		pcr.train()
-		pcr.saveModel('nnmodel.bin')
-	elif mode == 'file':
-		if len(sys.argv) < 3:
-			printUsage()
-		fileName = sys.argv[2]
-		pcr.loadModel('nnmodel.bin')
-		print pcr.predict([fileName])[0]
-	elif mode == 'url':
-		if len(sys.argv) < 3:
-			printUsage()
-		url = sys.argv[2]
-		f = open('tmp.jpg', 'wb')
-		f.write(urllib2.urlopen(url).read())
-		f.close()
-		pcr.loadModel('nnmodel.bin')
-		print pcr.predict(['tmp.jpg'])[0]
-		os.remove('tmp.jpg')
-	else:
-		printUsage()
+    if len(sys.argv) < 2:
+        printUsage()
+    mode = sys.argv[1]
+    if mode == 'train':
+        pcr.train()
+        pcr.saveModel('nnmodel.bin')
+    elif mode == 'file':
+        if len(sys.argv) < 3:
+            printUsage()
+        fileName = sys.argv[2]
+        pcr.loadModel('nnmodel.bin')
+        print(pcr.predict([fileName])[0])
+    elif mode == 'url':
+        if len(sys.argv) < 3:
+            printUsage()
+        url = sys.argv[2]
+        f = open('tmp.jpg', 'wb')
+        f.write(urlopen(url).read())
+        f.close()
+        pcr.loadModel('nnmodel.bin')
+        print(pcr.predict(['tmp.jpg'])[0])
+        os.remove('tmp.jpg')
+    else:
+        printUsage()

--- a/pcr.py
+++ b/pcr.py
@@ -2,20 +2,24 @@
 
 import os
 import sys
-import pickle
 import zlib
 import cv2
-import numpy as np
-import urllib2
 import time
 import random
-from Queue import Queue
 from threading import Thread
 from sklearn.cluster import MiniBatchKMeans
 from scipy.sparse import lil_matrix, csr_matrix
 from sklearn.feature_extraction.text import TfidfTransformer
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.ensemble import AdaBoostClassifier
+try:
+    import cPickle as pickle
+    from urllib2 import urlopen
+    from Queue import Queue
+except ImportError:
+    import pickle
+    from urllib.request import urlopen
+    from queue import Queue
 
 FILE_LOAD_THREADS = 1
 FILE_SEED = 24
@@ -28,229 +32,234 @@ USE_CACHE = True
 
 _g_removed = False
 
+
 class PCR:
-  
-  def __init__(self):
-    self.__clustersNumber = CLUSTERS_NUMBER
-    self.__queue = Queue()
-    self.__verbose = VERBOSE
-    self.__useCache = USE_CACHE
 
-    for i in range(FILE_LOAD_THREADS):
-      t = Thread(target = self.__worker)
-      t.daemon = True
-      t.start()
-    
-    self.__kmeans = MiniBatchKMeans(n_clusters = self.__clustersNumber, random_state = CLUSTER_SEED, verbose = self.__verbose)
-    self.__tfidf = TfidfTransformer()
-    self.__tfidf1 = TfidfTransformer()
-    
-    self.__clf = AdaBoostClassifier(MultinomialNB(alpha = BAYES_ALPHA), n_estimators = ADA_BOOST_ESTIMATORS)
-    self.__clf1 = AdaBoostClassifier(MultinomialNB(alpha = BAYES_ALPHA), n_estimators = ADA_BOOST_ESTIMATORS)
-    
-  def __worker(self):
-    while True:
-      task = self.__queue.get()
-      func, args = task
-      try:
-        func(args)
-      except Exception as e:
-        print 'EXCEPTION:', e
-      self.__queue.task_done()
-  
-  def train(self, positiveFiles, negativeFiles):
-    cachedData = self.__loadCache()
-    if cachedData is None:
-      self.__log('loading positives')
-      positiveSamples = self.__loadSamples(positiveFiles)
-      self.__log('loading negatives')
-      negativeSamples = self.__loadSamples(negativeFiles)
-    
-      totalDescriptors = []
-      self.__addDescriptors(totalDescriptors, positiveSamples)
-      self.__addDescriptors(totalDescriptors, negativeSamples)
-      
-      self.__kmeans.fit(totalDescriptors)
-      clusters = self.__kmeans.predict(totalDescriptors)
+    def __init__(self):
+        self.__clustersNumber = CLUSTERS_NUMBER
+        self.__queue = Queue()
+        self.__verbose = VERBOSE
+        self.__useCache = USE_CACHE
 
-      self.__printDistribution(clusters)
-      self.__saveCache((positiveSamples, negativeSamples, self.__kmeans, clusters))
-    else:
-      self.__log('using cache')
-      positiveSamples, negativeSamples, self.__kmeans, clusters = cachedData
-    
-    totalSamplesNumber = len(negativeSamples) + len(positiveSamples)
-    counts = lil_matrix((totalSamplesNumber, self.__clustersNumber))
-    counts1 = lil_matrix((totalSamplesNumber, 256))
-    self.__currentSample = 0
-    self.__currentDescr = 0
-    self.__calculteCounts(positiveSamples, counts, counts1, clusters)
-    self.__calculteCounts(negativeSamples, counts, counts1, clusters)
-    counts = csr_matrix(counts)
-    counts1 = csr_matrix(counts1)
-    
-    self.__log('training bayes classifier')
-    tfidf = self.__tfidf.fit_transform(counts)
-    tfidf1 = self.__tfidf1.fit_transform(counts1)
-    classes = [True] * len(positiveSamples) + [False] * len(negativeSamples)
-    self.__clf.fit(tfidf, classes)
-    self.__clf1.fit(tfidf1, classes)
-    
-    self.__log('training complete')
-  
-  def predict(self, files):
-    self.__log('loading files')
-    samples = self.__loadSamples(files)
-    totalDescriptors = []
-    self.__addDescriptors(totalDescriptors, samples)
-    self.__log('predicting classes')
-    clusters = self.__kmeans.predict(totalDescriptors)
-    counts = lil_matrix((len(samples), self.__clustersNumber))
-    counts1 = lil_matrix((len(samples), 256))
-    self.__currentSample = 0
-    self.__currentDescr = 0
-    self.__calculteCounts(samples, counts, counts1, clusters)
-    counts = csr_matrix(counts)
-    counts1 = csr_matrix(counts1)
-    
-    tfidf = self.__tfidf.transform(counts)
-    tfidf1 = self.__tfidf1.transform(counts1)
-    
-    self.__log('classifying')
-    
-    weights = self.__clf.predict_log_proba(tfidf.toarray())
-    weights1 = self.__clf1.predict_log_proba(tfidf1.toarray())
-    predictions = []
-    for i in xrange(0, len(weights)):
-      w = weights[i][0] - weights[i][1]
-      w1 = weights1[i][0] - weights1[i][1]
+        for i in range(FILE_LOAD_THREADS):
+            t = Thread(target=self.__worker)
+            t.daemon = True
+            t.start()
 
-      pred = w < 0
-      pred1 = w1 < 0
-      
-      if pred != pred1:
-        pred = w + w1 < 0
-      
-      predictions.append(pred)
-    
-    self.__log('prediction complete')
-    return predictions
-  
-  def saveModel(self, fileName):
-    data = pickle.dumps((self.__clustersNumber, self.__kmeans, self.__tfidf, self.__tfidf1, self.__clf, self.__clf1), -1)
-    data = zlib.compress(data)
-    open(fileName, 'w').write(data)
+        self.__kmeans = MiniBatchKMeans(
+            n_clusters=self.__clustersNumber,
+            random_state=CLUSTER_SEED,
+            verbose=self.__verbose)
+        self.__tfidf = TfidfTransformer()
+        self.__tfidf1 = TfidfTransformer()
 
-  def loadModel(self, fileName):
-    data = open(fileName, 'r').read()
-    data = zlib.decompress(data)
-    data = pickle.loads(data)
-    self.__clustersNumber, self.__kmeans, self.__tfidf, self.__tfidf1, self.__clf, self.__clf1 = data
-    
-  def __log(self, message):
-    if self.__verbose:
-      print message
-    
-  def __saveCache(self, data):
-    if not self.__useCache:
-      return
-    data = pickle.dumps(data, -1)
-    data = zlib.compress(data)
-    open('cache.bin', 'w').write(data)
-  
-  def __loadCache(self):
-    if not self.__useCache:
-      return None
-    if not os.path.isfile('cache.bin'):
-      return None
-    data = open('cache.bin', 'r').read()
-    data = zlib.decompress(data)
-    data = pickle.loads(data)
-    return data
-  
-  def __calculteCounts(self, samples, counts, counts1, clusters):
-    cn = self.__clustersNumber
-    for s in samples:
-      currentCounts = {}
-      for d in s[0]:
-        currentCounts[clusters[self.__currentDescr]] = currentCounts.get(clusters[self.__currentDescr], 0) + 1
-        self.__currentDescr += 1
-      for clu, cnt in currentCounts.iteritems():
-        counts[self.__currentSample, clu] = cnt
-      for i, histCnt in enumerate(s[1]):
-        counts1[self.__currentSample, i] = histCnt[0]
-      self.__currentSample += 1
-  
-  def __printDistribution(self, clusters):
-    if not self.__verbose:
-      return
-    distr = {}
-    for c in clusters:
-      distr[c] = distr.get(c, 0) + 1
-    v = sorted(distr.values(), reverse=True)
-    print 'distribution:', v[0:15], '...', v[-15:]
-  
-  def __addDescriptors(self, totalDescriptors, samples):
-    for sample in samples:
-      for descriptor in sample[0]:
-        totalDescriptors.append(descriptor)
-  
-  def __loadSamples(self, files):
-    samples = [[]] * len(files)
-    n = 0
-    for f in files:
-      self.__queue.put((self.__loadSingleSample, (f, samples, n)))
-      n += 1
-    self.__queue.join()
-    if _g_removed:
-      print ' === REMOVED = TERMINATE'
-      sys.exit(44)
-    return samples
-  
-  def __loadSingleSample(self, args):
-    global _g_removed
-    fileName, samples, sampleNum = args
-    des, hist = self.__getFeatures(fileName)
-    if des is None:
-      print 'ERROR: failed to load', fileName
-      os.remove(fileName)
-      _g_removed = True
-      #sys.exit(44)
-      des = []
-      hist = [[0]] * 256
-    samples[sampleNum] = (des, hist)
-  
-  def __getFeatures(self, fileName):
-    fid = 'cache/' + str(zlib.crc32(fileName))
-    self.__log('loading %s' % fileName)
-    if os.path.isfile(fid):
-      des, hist = pickle.loads(open(fid, 'rb').read())
-    else:
-      img = cv2.imread(fileName)
-      
-      if img.shape[1] > 1000:
-        cf = 1000.0 / img.shape[1]
-        newSize = (int(cf * img.shape[0]), int(cf * img.shape[1]), img.shape[2])
-        img.resize(newSize)
-      
-      gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        self.__clf = AdaBoostClassifier(MultinomialNB(alpha=BAYES_ALPHA), n_estimators=ADA_BOOST_ESTIMATORS)
+        self.__clf1 = AdaBoostClassifier(MultinomialNB(alpha=BAYES_ALPHA), n_estimators=ADA_BOOST_ESTIMATORS)
 
-      s = cv2.SIFT(nfeatures = 400)
-      
-      d = cv2.DescriptorExtractor_create("OpponentSIFT")
-      kp = s.detect(gray, None)
-      kp, des = d.compute(img, kp)
-      
-      hist = self.__getColorHist(img)
-      
-      #open(fid, 'wb').write(pickle.dumps((des, hist), -1))
-    
-    return des, hist
+    def __worker(self):
+        while True:
+            task = self.__queue.get()
+            func, args = task
+            try:
+                func(args)
+            except Exception as e:
+                print('EXCEPTION:', e)
+            self.__queue.task_done()
 
-  def __getColorHist(self, img):
-    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
-    dist = cv2.calcHist([hsv],[0],None,[256],[0,256])
-    return dist
+    def train(self, positiveFiles, negativeFiles):
+        cachedData = self.__loadCache()
+        if cachedData is None:
+            self.__log('loading positives')
+            positiveSamples = self.__loadSamples(positiveFiles)
+            self.__log('loading negatives')
+            negativeSamples = self.__loadSamples(negativeFiles)
+
+            totalDescriptors = []
+            self.__addDescriptors(totalDescriptors, positiveSamples)
+            self.__addDescriptors(totalDescriptors, negativeSamples)
+
+            self.__kmeans.fit(totalDescriptors)
+            clusters = self.__kmeans.predict(totalDescriptors)
+
+            self.__printDistribution(clusters)
+            self.__saveCache((positiveSamples, negativeSamples, self.__kmeans, clusters))
+        else:
+            self.__log('using cache')
+            positiveSamples, negativeSamples, self.__kmeans, clusters = cachedData
+
+        totalSamplesNumber = len(negativeSamples) + len(positiveSamples)
+        counts = lil_matrix((totalSamplesNumber, self.__clustersNumber))
+        counts1 = lil_matrix((totalSamplesNumber, 256))
+        self.__currentSample = 0
+        self.__currentDescr = 0
+        self.__calculteCounts(positiveSamples, counts, counts1, clusters)
+        self.__calculteCounts(negativeSamples, counts, counts1, clusters)
+        counts = csr_matrix(counts)
+        counts1 = csr_matrix(counts1)
+
+        self.__log('training bayes classifier')
+        tfidf = self.__tfidf.fit_transform(counts)
+        tfidf1 = self.__tfidf1.fit_transform(counts1)
+        classes = [True] * len(positiveSamples) + [False] * len(negativeSamples)
+        self.__clf.fit(tfidf, classes)
+        self.__clf1.fit(tfidf1, classes)
+
+        self.__log('training complete')
+
+    def predict(self, files):
+        self.__log('loading files')
+        samples = self.__loadSamples(files)
+        totalDescriptors = []
+        self.__addDescriptors(totalDescriptors, samples)
+        self.__log('predicting classes')
+        clusters = self.__kmeans.predict(totalDescriptors)
+        counts = lil_matrix((len(samples), self.__clustersNumber))
+        counts1 = lil_matrix((len(samples), 256))
+        self.__currentSample = 0
+        self.__currentDescr = 0
+        self.__calculteCounts(samples, counts, counts1, clusters)
+        counts = csr_matrix(counts)
+        counts1 = csr_matrix(counts1)
+
+        tfidf = self.__tfidf.transform(counts)
+        tfidf1 = self.__tfidf1.transform(counts1)
+
+        self.__log('classifying')
+
+        weights = self.__clf.predict_log_proba(tfidf.toarray())
+        weights1 = self.__clf1.predict_log_proba(tfidf1.toarray())
+        predictions = []
+        for i in range(0, len(weights)):
+            w = weights[i][0] - weights[i][1]
+            w1 = weights1[i][0] - weights1[i][1]
+
+            pred = w < 0
+            pred1 = w1 < 0
+
+            if pred != pred1:
+                pred = w + w1 < 0
+
+            predictions.append(pred)
+
+        self.__log('prediction complete')
+        return predictions
+
+    def saveModel(self, fileName):
+        data = pickle.dumps((self.__clustersNumber, self.__kmeans, self.__tfidf,
+                             self.__tfidf1, self.__clf, self.__clf1), -1)
+        data = zlib.compress(data)
+        open(fileName, 'wb').write(data)
+
+    def loadModel(self, fileName):
+        data = open(fileName, 'rb').read()
+        data = zlib.decompress(data)
+        data = pickle.loads(data)
+        self.__clustersNumber, self.__kmeans, self.__tfidf, self.__tfidf1, self.__clf, self.__clf1 = data
+
+    def __log(self, message):
+        if self.__verbose:
+            print(message)
+
+    def __saveCache(self, data):
+        if not self.__useCache:
+            return
+        data = pickle.dumps(data, -1)
+        data = zlib.compress(data)
+        open('cache.bin', 'w').write(data)
+
+    def __loadCache(self):
+        if not self.__useCache:
+            return None
+        if not os.path.isfile('cache.bin'):
+            return None
+        data = open('cache.bin', 'r').read()
+        data = zlib.decompress(data)
+        data = pickle.loads(data)
+        return data
+
+    def __calculteCounts(self, samples, counts, counts1, clusters):
+        cn = self.__clustersNumber
+        for s in samples:
+            currentCounts = {}
+            for d in s[0]:
+                currentCounts[clusters[self.__currentDescr]] = currentCounts.get(clusters[self.__currentDescr], 0) + 1
+                self.__currentDescr += 1
+            for clu, cnt in currentCounts.iteritems():
+                counts[self.__currentSample, clu] = cnt
+            for i, histCnt in enumerate(s[1]):
+                counts1[self.__currentSample, i] = histCnt[0]
+            self.__currentSample += 1
+
+    def __printDistribution(self, clusters):
+        if not self.__verbose:
+            return
+        distr = {}
+        for c in clusters:
+            distr[c] = distr.get(c, 0) + 1
+        v = sorted(distr.values(), reverse=True)
+        print('distribution:', v[0:15], '...', v[-15:])
+
+    def __addDescriptors(self, totalDescriptors, samples):
+        for sample in samples:
+            for descriptor in sample[0]:
+                totalDescriptors.append(descriptor)
+
+    def __loadSamples(self, files):
+        samples = [[]] * len(files)
+        n = 0
+        for f in files:
+            self.__queue.put((self.__loadSingleSample, (f, samples, n)))
+            n += 1
+        self.__queue.join()
+        if _g_removed:
+            print(' === REMOVED = TERMINATE')
+            sys.exit(44)
+        return samples
+
+    def __loadSingleSample(self, args):
+        global _g_removed
+        fileName, samples, sampleNum = args
+        des, hist = self.__getFeatures(fileName)
+        if des is None:
+            print('ERROR: failed to load', fileName)
+            os.remove(fileName)
+            _g_removed = True
+            # sys.exit(44)
+            des = []
+            hist = [[0]] * 256
+        samples[sampleNum] = (des, hist)
+
+    def __getFeatures(self, fileName):
+        fid = 'cache/' + str(zlib.crc32(fileName))
+        self.__log('loading %s' % fileName)
+        if os.path.isfile(fid):
+            des, hist = pickle.loads(open(fid, 'rb').read())
+        else:
+            img = cv2.imread(fileName)
+
+            if img.shape[1] > 1000:
+                cf = 1000.0 / img.shape[1]
+                newSize = (int(cf * img.shape[0]), int(cf * img.shape[1]), img.shape[2])
+                img.resize(newSize)
+
+            gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+
+            s = cv2.SIFT(nfeatures=400)
+
+            d = cv2.DescriptorExtractor_create("OpponentSIFT")
+            kp = s.detect(gray, None)
+            kp, des = d.compute(img, kp)
+
+            hist = self.__getColorHist(img)
+
+            #open(fid, 'wb').write(pickle.dumps((des, hist), -1))
+
+        return des, hist
+
+    def __getColorHist(self, img):
+        hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+        dist = cv2.calcHist([hsv], [0], None, [256], [0, 256])
+        return dist
 
 
 def loadDir(dirName):
@@ -263,94 +272,96 @@ def loadDir(dirName):
         fnames.append(fileName)
     return fnames
 
+
 def loadFileLists():
-  random.seed(FILE_SEED)
-  
-  positiveFiles = sorted(loadDir('2'))
-  negativeFiles = sorted(loadDir('1'))
-  
-  random.shuffle(positiveFiles)
-  random.shuffle(negativeFiles)
-  
-  minLen = min(len(positiveFiles), len(negativeFiles))
-  
-  p20 = int(0.2 * minLen)
-  
-  testFiles = positiveFiles[:p20] + negativeFiles[:p20]
-  positiveFiles = positiveFiles[p20:]
-  negativeFiles = negativeFiles[p20:]
-  
-  print testFiles[0], negativeFiles[0], positiveFiles[0]
-  
-  testFiles = loadDir('1test')
-  
-  return positiveFiles, negativeFiles, testFiles
-  
+    random.seed(FILE_SEED)
+
+    positiveFiles = sorted(loadDir('2'))
+    negativeFiles = sorted(loadDir('1'))
+
+    random.shuffle(positiveFiles)
+    random.shuffle(negativeFiles)
+
+    minLen = min(len(positiveFiles), len(negativeFiles))
+
+    p20 = int(0.2 * minLen)
+
+    testFiles = positiveFiles[:p20] + negativeFiles[:p20]
+    positiveFiles = positiveFiles[p20:]
+    negativeFiles = negativeFiles[p20:]
+
+    print(testFiles[0], negativeFiles[0], positiveFiles[0])
+
+    testFiles = loadDir('1test')
+
+    return positiveFiles, negativeFiles, testFiles
+
 
 def train():
-  positiveFiles, negativeFiles, testFiles = loadFileLists()
+    positiveFiles, negativeFiles, testFiles = loadFileLists()
 
-  pcr = PCR()
-  pcr.train(positiveFiles, negativeFiles)
-  pcr.saveModel('model.bin')
-  
-  
+    pcr = PCR()
+    pcr.train(positiveFiles, negativeFiles)
+    pcr.saveModel('model.bin')
+
+
 def predict():
-  
-  positiveFiles, negativeFiles, testFiles = loadFileLists()
-  testFiles = testFiles
-  
-  pcr = PCR()
-  pcr.loadModel('model.bin')
-  pred = pcr.predict(testFiles)
-  total = 0
-  correct = 0
 
-  for i in xrange(0, len(testFiles)):
-    isCorrect = ((testFiles[i][0] == '1' and not pred[i]) or (testFiles[i][0] == '2' and pred[i]))
+    positiveFiles, negativeFiles, testFiles = loadFileLists()
+    testFiles = testFiles
 
-    print isCorrect, pred[i], testFiles[i]
-    #if not isCorrect:
-    #  print testFiles[i]
-    correct += int(isCorrect)
+    pcr = PCR()
+    pcr.loadModel('model.bin')
+    pred = pcr.predict(testFiles)
+    total = 0
+    correct = 0
 
-    
-    total += 1
-  print 'sum: \t', float(correct) / total
+    for i in xrange(0, len(testFiles)):
+        isCorrect = ((testFiles[i][0] == '1' and not pred[i]) or (testFiles[i][0] == '2' and pred[i]))
+
+        print(isCorrect, pred[i], testFiles[i])
+        # if not isCorrect:
+        #  print testFiles[i]
+        correct += int(isCorrect)
+
+        total += 1
+    print('sum: \t', float(correct) / total)
+
 
 def predictTest():
-  files = ['test.jpg']
-  pcr = PCR()
-  pcr.loadModel('model.bin')
-  pred = pcr.predict(files)
-  print '\n\n ===', pred[0], '===\n\n'
-  
+    files = ['test.jpg']
+    pcr = PCR()
+    pcr.loadModel('model.bin')
+    pred = pcr.predict(files)
+    print('\n\n ===', pred[0], '===\n\n')
+
+
 def predictUrl(url):
-  f = open('test.jpg','wb')
-  f.write(urllib2.urlopen(url).read())
-  f.close()
-  time.sleep(0.5)
-  predictTest()
+    f = open('test.jpg', 'wb')
+    f.write(urlopen(url).read())
+    f.close()
+    time.sleep(0.5)
+    predictTest()
+
 
 def printUsage():
-  print 'Usage: '
-  print '  %s train                              - train model' % sys.argv[0]
-  print '  %s url http://sample.com/img.jpg      - check given url' % sys.argv[0]
-  sys.exit(42)
+    print('Usage: ')
+    print('  %s train                              - train model' % sys.argv[0])
+    print('  %s url http://sample.com/img.jpg      - check given url' % sys.argv[0])
+    sys.exit(42)
 
 if __name__ == '__main__':
-  if len(sys.argv) < 2:
-    printUsage()
-  mode = sys.argv[1]
-  if mode == 'train':
-    train()
-    time.sleep(0.5)
-    predict()
-  elif mode == 'url':
-    if len(sys.argv) < 3:
-      printUsage()
-    url = sys.argv[2]
-    predictUrl(url)
-  else:
-    printUsage()
-
+    if len(sys.argv) < 2:
+        printUsage()
+    mode = sys.argv[1]
+    if mode == 'train':
+        train()
+        time.sleep(0.5)
+        predict()
+    elif mode == 'url':
+        if len(sys.argv) < 3:
+            printUsage()
+        url = sys.argv[2]
+        predictUrl(url)
+    else:
+        printUsage()


### PR DESCRIPTION
I ran `autopep8` so it's in the standard python formatting
and fixed the imports and print statements to work in python3 as well.

I only tested it with tensorflow since for python3 you need opencv3 where
the `SIFT` module is not included by default and you have to compile it extra from `opencv_contrib`
